### PR TITLE
Update to pull_request_target

### DIFF
--- a/.github/workflows/new-items.yml
+++ b/.github/workflows/new-items.yml
@@ -13,7 +13,7 @@ on:
   issues:
     types:
       - opened
-  pull_request:
+  pull_request_target:
     types:
       - ready_for_review
       - opened


### PR DESCRIPTION
Update workflow to use pull_request_target instead of pull_request to run workflow in the context of the DCC-EX repo instead of the fork.